### PR TITLE
Make the `parse_slurm_tasks_per_node` function part of the public API of this package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SlurmAddAllocatedProcs"
 uuid = "4b0af0f2-a3e4-42c8-afa2-c5af2ee86004"
 authors = ["Jishnu Bhattacharya <jishnub@users.noreply.github.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 ClusterManagers = "34f1f09b-3a8b-5176-ab39-66d58a4d544e"

--- a/src/SlurmAddAllocatedProcs.jl
+++ b/src/SlurmAddAllocatedProcs.jl
@@ -2,8 +2,9 @@ module SlurmAddAllocatedProcs
 
 using ClusterManagers
 export addprocs_slurm_allocated
+export parse_slurm_tasks_per_node
 
-function parse_SLURM_TASKS_PER_NODE(SLURM_TASKS_PER_NODE)
+function parse_slurm_tasks_per_node(SLURM_TASKS_PER_NODE)
     v = split(SLURM_TASKS_PER_NODE, ",")
     pattern = r"([0-9]+)\(x([0-9]+)\)"
     np = 0
@@ -37,7 +38,7 @@ variables set by the resource allocation step (eg. using `sbatch` flags).
 """
 function addprocs_slurm_allocated()
     SLURM_TASKS_PER_NODE = get(ENV, "SLURM_TASKS_PER_NODE", "")
-    np = parse_SLURM_TASKS_PER_NODE(SLURM_TASKS_PER_NODE)
+    np = parse_slurm_tasks_per_node(SLURM_TASKS_PER_NODE)
     addprocs_slurm(np)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,13 @@
 using SlurmAddAllocatedProcs
-using SlurmAddAllocatedProcs: parse_SLURM_TASKS_PER_NODE
 using Test
 
 @testset "SlurmAddAllocatedProcs.jl" begin
     @test_throws ErrorException addprocs_slurm_allocated()
-    @testset "parse_SLURM_TASKS_PER_NODE" begin
-        @test parse_SLURM_TASKS_PER_NODE("28(x3)") == 28*3
-        @test parse_SLURM_TASKS_PER_NODE("28(x3),1") == 28*3+1
-        @test parse_SLURM_TASKS_PER_NODE("2,28(x2),1") == 2+28*2+1
-        @test parse_SLURM_TASKS_PER_NODE("2,28(x2),1,28(x4)") == 2+28*2+1+28*4
+    @testset "parse_slurm_tasks_per_node" begin
+        @test parse_slurm_tasks_per_node("28(x3)") == 28*3
+        @test parse_slurm_tasks_per_node("28(x3),1") == 28*3+1
+        @test parse_slurm_tasks_per_node("2,28(x2),1") == 2+28*2+1
+        @test parse_slurm_tasks_per_node("2,28(x2),1,28(x4)") == 2+28*2+1+28*4
     end
 end
 

--- a/test/script.jl
+++ b/test/script.jl
@@ -5,6 +5,6 @@ addprocs_slurm_allocated()
 using Distributed
 
 SLURM_TASKS_PER_NODE = ENV["SLURM_TASKS_PER_NODE"]
-@test nworkers() == SlurmAddAllocatedProcs.parse_SLURM_TASKS_PER_NODE(SLURM_TASKS_PER_NODE)
+@test nworkers() == parse_slurm_tasks_per_node(SLURM_TASKS_PER_NODE)
 hosts = [@fetchfrom w Libc.gethostname() for w in workers()]
 @test length(unique(hosts)) == parse(Int, ENV["SLURM_JOB_NUM_NODES"])


### PR DESCRIPTION
This allows users to potentially, do other stuff with the return value, instead of immediately passing the value to `ClusterManagers.addprocs_slurm`.